### PR TITLE
Make sidebar items flex containers.

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,6 +64,7 @@ function loadFiles(){
             loadFile(item)
         })
         fileDiv.className = "file"
+	fileDiv.title = item.name
         fileDiv.id = "file_"+item.name
         var a = document.createElement("a");
         a.className = 'asdf-container'

--- a/style.css
+++ b/style.css
@@ -20,7 +20,10 @@ body {
     text-decoration: none;
     font-size: 20px;
     color: #818181;
-    display: inline;
+    flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .sidenav h1 {
     padding: 6px 8px 6px 16px;
@@ -32,6 +35,7 @@ body {
 
   .file{
     transition: background-color 0.25s;
+    display: flex;
     padding: 10px;
     overflow: hidden;
     background-color: #23232e;


### PR DESCRIPTION
Fixes #8. (Probably?)

Makes sidebar items flex containers, which allows long file names to be truncated. It also adds tooltips so you can still read the full name.

Screenshot:
![Screenshot](http://u.cubeupload.com/MaxiMouse/notedtrunc.png)